### PR TITLE
Update default_variant_schema.yaml

### DIFF
--- a/default_variant_schema.yaml
+++ b/default_variant_schema.yaml
@@ -72,16 +72,16 @@ components:
           example: SO:0001483
         start:
           description: |
-            Start position of variant.
+            Start position of the variant in 0-based (interbase) coordinates.
           type: integer
           format: int64
           minimum: 0
         end:
           description: |
-            End position of variant
+            End position of the variant in 0-based (interbase) coordinates.
           type: integer
           format: int64
-          minimum: 0
+          minimum: 1
         assemblyId:
           description: |
             Genomic assembly accession as Genome Reference consortium Human 


### PR DESCRIPTION
Added  "0-based (interbase)" description and fix for `end`. I.e. a single base variant at start 10 will have end at 11 and a length of `end - start = 1`.