### PR TITLE
chromosome => referenceName

### DIFF
--- a/default_variant_schema.yaml
+++ b/default_variant_schema.yaml
@@ -52,7 +52,7 @@ components:
         Description of the variant.
       type: object
       properties:
-        chromosome:
+        referenceName:
           $ref: '#/components/schemas/Chromosome'
         referenceBases:
           description: |


### PR DESCRIPTION
The attribute is `referenceName` in the Beacon specification, and `chromosome` is factually incorrect, if extending to more use cases. Also, the `Chromosome` component should be changed - see issue #9 . This is not addressed here since `Chromosome` is used as component in the Beacon spec., too and should be aligned.