### PR TITLE
make identifiers required

### DIFF
--- a/default_analysis_schema.yaml
+++ b/default_analysis_schema.yaml
@@ -21,6 +21,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'analysisId'
       properties:
         analysisId:
           description: Analysis reference ID (external accession or internal ID)

--- a/default_biosample_schema.yaml
+++ b/default_biosample_schema.yaml
@@ -41,6 +41,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'biosampleId'
       properties:
         biosampleId:
           description: |

--- a/default_cohort_schema.yaml
+++ b/default_cohort_schema.yaml
@@ -162,11 +162,13 @@ components:
       description: |
         Level/severity ontology when and as applicable to phenotype observed. Value from TBD, e.g "mild"
       type: object
+      required: 
+        - 'cohortId'
       properties:
         cohortType:
           description: |
             Cohort type by its definition. If a cohort is declared ´study-defined´ or ´beacon-defined´, 
-            criteria are to be entered in cohort_inclusion_criteria; if a cohort is declared ‘user-defined'
+            criteria are to be entered in cohort_inclusion_criteria; if a cohort is declared ´user-defined´
             cohort_inclusion_criteria could be automatically populated from the parameters used to perform the query.
           type: string
           enum:

--- a/default_individual_schema.yaml
+++ b/default_individual_schema.yaml
@@ -231,6 +231,8 @@ components:
       description: |
         #TBD
       type: object
+      required: 
+        - 'individualId'
       properties:
         individualId:
           description: |

--- a/default_interactor_schema.yaml
+++ b/default_interactor_schema.yaml
@@ -231,6 +231,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'individualId'
       properties:
         relationType:
           description: |

--- a/default_run_schema.yaml
+++ b/default_run_schema.yaml
@@ -21,6 +21,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'runId'
       properties:
         runId:
           description: |

--- a/default_variant_annotations_schema.yaml
+++ b/default_variant_annotations_schema.yaml
@@ -42,6 +42,8 @@ components:
     VariantAnnotation:
       description: TBD # TBD
       type: object
+      required: 
+        - 'variantId'
       properties:
         variantId:
           description: |

--- a/default_variant_identification_schema.yaml
+++ b/default_variant_identification_schema.yaml
@@ -21,6 +21,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'variantId'
       properties:
         variantId:
           description: |

--- a/default_variant_in_sample_schema.yaml
+++ b/default_variant_in_sample_schema.yaml
@@ -73,9 +73,11 @@ components:
       description: |
         Todo
       type: object
-      required: 
-        - 'variantId'
-        - 'biosampleId'
+      anyOf:
+        - required:
+          - 'biosampleId'
+        - required:
+          - 'analysisId'  
       properties:
         variantId:
           description: |

--- a/default_variant_in_sample_schema.yaml
+++ b/default_variant_in_sample_schema.yaml
@@ -73,6 +73,9 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'variantId'
+        - 'biosampleId'
       properties:
         variantId:
           description: |

--- a/default_variant_in_sample_schema.yaml
+++ b/default_variant_in_sample_schema.yaml
@@ -124,7 +124,7 @@ components:
         phenotypicEffect:
           type: array
           items:
-            $ref: '#/components/schemas/phenotypicEffect'
+            $ref: '#/components/schemas/PhenotypicEffect'
         info:
           description: |
             Additional unspecified metadata about the dataset response or its 

--- a/default_variant_interpretation_schema.yaml
+++ b/default_variant_interpretation_schema.yaml
@@ -114,6 +114,8 @@ components:
       description: |
         Todo
       type: object
+      required: 
+        - 'variantId'
       properties:
         variantId:
           description: |


### PR DESCRIPTION
Any schema with no **required** properties would authenticate any arbitrary object.
To distinguish default schema objects from any other json objects; I suggest to make the identifiers mandatory.
For instance, 'VariantInSample' have two 'required' identifiers - 'variantId' and  'biosampleId'.
It is possible that more properties can be made mandatory.